### PR TITLE
Suggestions

### DIFF
--- a/helix-update/index.md
+++ b/helix-update/index.md
@@ -11,7 +11,7 @@ q3 2019
 
 
 # Zen
-> Intelligent digital experience creation and delivery<br> for the next 25 years.
+> Intelligent digital experience creation and delivery<br> for the next 20 years.
 
 ---
 


### PR DESCRIPTION
I suggest we change "AEM X" to "AEM Sites X" since the main focus for Helix is CMS, not all the rest (Assets, Forms etc) we have in AEM today.

Also, we talk about AEM being 20 years old, so I guess it's more logical to say Helix is for the next 20 years. Wdyt?